### PR TITLE
remove duplicate element

### DIFF
--- a/kdbx-xml/kdbx4.0-schema.xsd
+++ b/kdbx-xml/kdbx4.0-schema.xsd
@@ -141,7 +141,6 @@
             <xs:element name="HeaderHash" type="xs:base64Binary" minOccurs="0"/>
             <xs:element name="SettingsChanged" type="xs:dateTime" minOccurs="0"/>
             <xs:element name="Generator" type="xs:string" minOccurs="0"/>
-            <xs:element name="SettingsChanged" type="xs:dateTime" minOccurs="0"/>
             <xs:element name="DatabaseName" type="xs:string" minOccurs="0"/>
             <xs:element name="DatabaseNameChanged" type="xs:dateTime" minOccurs="0"/>
             <xs:element name="DatabaseDescription" type="xs:string" minOccurs="0"/>


### PR DESCRIPTION
The duplicate element causes issues when parsing the schema in `lxml`.

``` python
from lxml import etree
schema = etree.XMLSchema(file='kdbx4.0-schema.xsd')
# XMLSchemaParseError: complex type 'MetaType': The content model is not determinist., line 139
```

Also, I had to comment out line 123 because it seems like `ProtectionAttributes` is not defined.  Not sure how to fix that:
``` python
# XMLSchemaParseError: Element '{http://www.w3.org/2001/XMLSchema}attributeGroup', attribute 'ref': The QName value '{https://keepassxc.org/schema/kdbx/4.0/}ProtectionAttributes' does not resolve to a(n) attribute group definition., line 123
```